### PR TITLE
Add support for standalone mode from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You can change the `--name` and **make sure you specify a valid local full path 
 
 You can fetch a working sample config from the [Github repo](https://github.com/WietseWind/docker-rippled).
 
+To start the container in standalone mode, you can specify the environment variable `STANDALONE_MODE` with `-e STANDALONE_MODE=True` or add `-a --start` as args.
+
 ## So it's running
 
 If you want to check the rippled-logs (container stdout, press CTRL - C to stop watching):

--- a/entrypoint
+++ b/entrypoint
@@ -14,5 +14,10 @@ if [[ "$rippledconfig" -gt "0" && "$validatorstxt" -gt "0" ]]; then
 
 fi
 
+ENV_ARGS = ""
+if [[ ! -z "${STANDALONE_MODE}" ]]; then
+  ENV_ARGS="${ENV_ARGS} -a --start"
+fi
+
 # Start rippled, Passthrough other arguments
-exec /opt/ripple/bin/rippled --conf /etc/opt/ripple/rippled.cfg "$@"
+exec /opt/ripple/bin/rippled --conf /etc/opt/ripple/rippled.cfg $ENV_ARGS "$@"


### PR DESCRIPTION
I'd like to use this as part of xrpl.js and xrpl-py's integration tests, but currently am unable to because we need to start the container in standalone mode and GitHub actions' `services` feature doesn't support passing in args to a container directly. 

Previously we forked this repo, but that led to the problem of falling out of date with the latest rippled changes. ([This is the setup on xrpl.js for reference](https://github.com/XRPLF/xrpl.js/blob/0fa5415d297845c6f59d7c0e350cfb6dd7d199ea/.github/workflows/nodejs.yml#L154))

So, since GitHub actions allows flags to be passed in, my proposed fix is to add an option to pass in the environment variable `STANDALONE_MODE` which starts the container in standalone mode. 

(I'm open to other better ways to go about this. This seemed like the simplest change to me.)