### PR TITLE
Fix small typos in README example scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You can change the `--name` and **make sure you specify a valid local full path 
 
 You can fetch a working sample config from the [Github repo](https://github.com/WietseWind/docker-rippled).
 
+To start the container in standalone mode, you can specify the environment variable `STANDALONE_MODE` with `-e STANDALONE_MODE=True` or add `-a --start` as args.
+
 ## So it's running
 
 If you want to check the rippled-logs (container stdout, press CTRL - C to stop watching):

--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ Both environment variables passed with `-e` to `docker run` and arguments added 
 ```bash
 docker run \
   -e TESTVAR=123123 \
-  -it --name xrpld -p $PORT:80 \
+  -it --name rippled -p $PORT:80 \
   -v $(pwd)/../config:/config/ \
   xrpllabsofficial/xrpld:latest \
   -a \
-  -start
+  --start
 ```
 
 ... will pass the environment variable `TESTVAR` with value, and the arguments `-aaa` and `-c` to `rippled`.
 
-Alternatively, if you can't pass direct arguments, you can pass a string of arguments as an environment variable called `ENV_VARS`, like this:
+Alternatively, if you can't pass direct arguments, you can pass a string of arguments as an environment variable called `ENV_ARGS`, like this:
 
 ```bash
 docker run \
-  -e ENV_VARS=-a --start \
-  -it --name xrpld -p $PORT:80 \
+  -e ENV_ARGS="-a --start" \
+  -it --name rippled -p $PORT:80 \
   -v $(pwd)/../config:/config/ \
   xrpllabsofficial/xrpld:latest
 ```

--- a/entrypoint
+++ b/entrypoint
@@ -24,10 +24,5 @@ if [[ "$rippledconfig" -gt "0" && "$validatorstxt" -gt "0" ]]; then
 
 fi
 
-ENV_ARGS = ""
-if [[ ! -z "${STANDALONE_MODE}" ]]; then
-  ENV_ARGS="${ENV_ARGS} -a --start"
-fi
-
 # Start rippled, Passthrough other arguments
 exec /opt/ripple/bin/rippled --conf /etc/opt/ripple/rippled.cfg $@$ENV_ARGS

--- a/entrypoint
+++ b/entrypoint
@@ -14,5 +14,10 @@ if [[ "$rippledconfig" -gt "0" && "$validatorstxt" -gt "0" ]]; then
 
 fi
 
+ENV_ARGS = ""
+if [[ ! -z "${STANDALONE_MODE}" ]]; then
+  ENV_ARGS="${ENV_ARGS} -a --start"
+fi
+
 # Start rippled, Passthrough other arguments
-exec /opt/ripple/bin/rippled --conf /etc/opt/ripple/rippled.cfg "$@"
+exec /opt/ripple/bin/rippled --conf /etc/opt/ripple/rippled.cfg $ENV_ARGS "$@"


### PR DESCRIPTION
As written the new example scripts don't quite work, so opening this PR to update them. 

Specifically:
* `ENV_VARS` should be `ENV_ARGS` according to the `entrypoint.sh` file.
* `-a --start` needs quotes around it or it will try to treat `--start` as a docker flag, which is invalid
* And I standardized the name to `rippled` instead of `xrpld` since the rest of the instructions assume the container is called `rippled`
* `-start` -> `--start` for proper rippled syntax